### PR TITLE
Add a library version of wappaGo

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ or
 go install github.com/EasyRecon/wappaGo@latest
 ```
 
-**Note :** _wappaGo requires Chrome to be present on the system and on Linux & MacOS wappaGo must be root_
+**Note :** _wappaGo requires Chrome to be present on the system_
 
 # Usage
 
@@ -76,6 +76,70 @@ or from an Amass output  (preferred)
 amass enum -d example.com -ipv4 -json out.json
 cat out.json | ./wappaGo -amass-input
 ```
+
+# Library
+
+You can use wappaGo as a library in your own project.
+
+## Options
+      
+```go
+type WrapperOptions struct {
+	Screenshot     string
+	Ports          string
+	Threads        int
+	Porttimeout    int
+	Resolvers      string
+	FollowRedirect bool
+	ChromeTimeout  int
+	ChromeThreads  int
+	Proxy          string
+}
+```
+
+## Example
+
+```go
+package main
+
+import (
+	"fmt"
+
+	"github.com/EasyRecon/wappaGo/structure"
+	"github.com/EasyRecon/wappaGo/wrapper"
+)
+
+func main() {
+	input := []string{"google.com", "twitter.com"}
+
+	options := structure.WrapperOptions{
+		Ports:      "80,443",
+		Screenshot: "screenshots",
+	}
+
+      // Async mode
+
+	results := make(chan structure.Data)
+
+	go func() {
+		for result := range results {
+			fmt.Println(result)
+		}
+	}()
+
+	wrapper.StartReconAsync(input, options, results)
+
+      // Sync mode
+
+      results := wrapper.StartReconSync(input, options)
+
+	for _, result := range results {
+		fmt.Println(result)
+	}
+}
+```
+
+For each url, you will receive a structure.Data which contains all the information about the target.
 
 ## Todo
 

--- a/structure/structure.go
+++ b/structure/structure.go
@@ -2,6 +2,7 @@ package structure
 
 import (
 	"time"
+
 	"github.com/projectdiscovery/cryptoutil"
 )
 
@@ -15,7 +16,7 @@ type Technologie struct {
 const WappazlyerRoot = "https://raw.githubusercontent.com/wappalyzer/wappalyzer/master/src"
 const LetterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
 
-var InterrestingKey = []string{"dns", "js", "meta", "text", "dom", "script", "html", "scriptSrc", "headers", "cookies", "url","certIssuer","xhr"}
+var InterrestingKey = []string{"dns", "js", "meta", "text", "dom", "script", "html", "scriptSrc", "headers", "cookies", "url", "certIssuer", "xhr"}
 
 type Host struct {
 	Status_code    int           `json:"status_code"`
@@ -49,8 +50,19 @@ type Options struct {
 	FollowRedirect *bool
 	ChromeTimeout  *int
 	ChromeThreads  *int
-	Report		   *bool
-	Proxy		   *string
+	Report         *bool
+	Proxy          *string
+}
+type WrapperOptions struct {
+	Screenshot     string
+	Ports          string
+	Threads        int
+	Porttimeout    int
+	Resolvers      string
+	FollowRedirect bool
+	ChromeTimeout  int
+	ChromeThreads  int
+	Proxy          string
 }
 type Response struct {
 	StatusCode    int
@@ -62,9 +74,9 @@ type Response struct {
 	Words         int
 	Lines         int
 	TLSData       *cryptoutil.TLSData
-	HTTP2    	  bool
-	Pipeline 	  bool
-	Duration 	  time.Duration
+	HTTP2         bool
+	Pipeline      bool
+	Duration      time.Duration
 }
 
 type PortOpenByIp struct {

--- a/wrapper/root.go
+++ b/wrapper/root.go
@@ -1,0 +1,74 @@
+package wrapper
+
+import (
+	"errors"
+	"log"
+	"os"
+
+	"github.com/EasyRecon/wappaGo/cmd"
+	"github.com/EasyRecon/wappaGo/structure"
+	"github.com/EasyRecon/wappaGo/technologies"
+)
+
+func StartReconAsync(input []string, wrapperOptions structure.WrapperOptions, results chan structure.Data) {
+	c := configureOptions(wrapperOptions)
+	c.Input = input
+
+	c.Start(results)
+}
+
+func StartReconSync(input []string, wrapperOptions structure.WrapperOptions) []structure.Data {
+	c := configureOptions(wrapperOptions)
+	c.Input = input
+
+	var resultGlobal []structure.Data
+
+	results := make(chan structure.Data)
+	go func() {
+		for result := range results {
+			resultGlobal = append(resultGlobal, result)
+		}
+	}()
+
+	c.Start(results)
+
+	return resultGlobal
+}
+
+func configureOptions(wrapperOptions structure.WrapperOptions) cmd.Cmd {
+	options := structure.Options{}
+	falseBool := false
+
+	options.Screenshot = &wrapperOptions.Screenshot
+	options.Ports = &wrapperOptions.Ports
+	options.Threads = &wrapperOptions.Threads
+	options.Report = &falseBool
+	options.Porttimeout = &wrapperOptions.Porttimeout
+	options.ChromeTimeout = &wrapperOptions.ChromeTimeout
+	options.ChromeThreads = &wrapperOptions.ChromeThreads
+	options.Resolvers = &wrapperOptions.Resolvers
+	options.AmassInput = &falseBool
+	options.FollowRedirect = &wrapperOptions.FollowRedirect
+	options.Proxy = &wrapperOptions.Proxy
+
+	if *options.Screenshot != "" {
+		if _, err := os.Stat(*options.Screenshot); errors.Is(err, os.ErrNotExist) {
+			err := os.Mkdir(*options.Screenshot, os.ModePerm)
+			if err != nil {
+				log.Println(err)
+			}
+		}
+	}
+
+	folder, errDownload := technologies.DownloadTechnologies()
+	if errDownload != nil {
+		log.Println("error during downloading techno file")
+	}
+	defer os.RemoveAll(folder)
+
+	c := cmd.Cmd{}
+	c.ResultGlobal = technologies.LoadTechnologiesFiles(folder)
+	c.Options = options
+
+	return c
+}


### PR DESCRIPTION
Hi !

For my own project, I need to use wappaGo as a library in order to import it and make scans without using commands.

I did it by creating a wrapper in front of the already used engine. And I made two functions **_wrapper.StartReconAsync_** and **_wrapper.StartReconSync_**.

You can now simply import it in your project and use wappaGo.

Regards,
Aituglo